### PR TITLE
Fix readability of #time method

### DIFF
--- a/druuid.rb
+++ b/druuid.rb
@@ -35,7 +35,7 @@ module Druuid
     #   # => 2012-02-04 00:00:00 -0800
     def time uuid, epoch_offset = epoch
       ms = uuid >> (64 - 41)
-      Time.at (ms / 1e3) + epoch_offset.to_i
+      Time.at(ms / 1e3) + epoch_offset.to_i
     end
 
   end


### PR DESCRIPTION
With that extra space after `Time.at`, this could be interpreted by a human as

```ruby
result = (ms / 1e3) + epoch_offset.to_i
Time.at result
```

which it is not.