### PR TITLE
Add method to return the lowest druuid for a time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor
+.bundle

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    druuid (1.0.1)
+    druuid (1.0.2)
 
 GEM
   remote: https://rubygems.org/
@@ -24,3 +24,6 @@ DEPENDENCIES
   druuid!
   rake
   rspec
+
+BUNDLED WITH
+   1.11.2

--- a/README.markdown
+++ b/README.markdown
@@ -76,8 +76,10 @@ require 'druuid'
 
 uuid = Druuid.gen
 # => 11142943683383068069
-Druuid.time uuid
+time = Druuid.time uuid
 # => 2012-02-04 00:00:00 -0800
+Druuid.min_for_time time
+# => 11142943683379200000
 ```
 
 

--- a/druuid.gemspec
+++ b/druuid.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'druuid'
-  s.version = '1.0.1'
+  s.version = '1.0.2'
   s.summary = 'Date-relative UUID generation'
   s.description = 'Druuid generates 64-bit, time-sortable UUIDs.'
 

--- a/druuid.rb
+++ b/druuid.rb
@@ -4,6 +4,7 @@ require 'securerandom'
 #
 # Date-relative UUID generation.
 module Druuid
+  NUM_RANDOM_BITS = 64 - 41
 
   class << self
 
@@ -21,8 +22,8 @@ module Druuid
     def gen time = Time.now, epoch_offset = epoch
       ms = ((time.to_f - epoch_offset.to_i) * 1e3).round
       rand = (SecureRandom.random_number * 1e16).round
-      id = ms << (64 - 41)
-      id | rand % (2 ** (64 - 41))
+      id = ms << NUM_RANDOM_BITS
+      id | rand % (2 ** NUM_RANDOM_BITS)
     end
 
     # Determines when a given UUID was generated.
@@ -34,8 +35,21 @@ module Druuid
     #   Druuid.time 11142943683383068069
     #   # => 2012-02-04 00:00:00 -0800
     def time uuid, epoch_offset = epoch
-      ms = uuid >> (64 - 41)
+      ms = uuid >> NUM_RANDOM_BITS
       Time.at(ms / 1e3) + epoch_offset.to_i
+    end
+
+    # Determines the minimum UUID that could be generated for the given time.
+    #
+    # @param [Time] time of UUID
+    # @param [Numeric] epoch offset
+    # @return [Bignum] UUID
+    # @example
+    #   Druuid.min_for_time
+    #   # => 11142943683379200000
+    def min_for_time time = Time.now, epoch_offset = epoch
+      ms = ((time.to_f - epoch_offset.to_i) * 1e3).round
+      ms << NUM_RANDOM_BITS
     end
 
   end


### PR DESCRIPTION
* Adds method the returns the lowest druuid that could be generated for a given time.
* Extracts a shared NUM_RANDOM_BITS const for the repeating ’64 - 41’
* Extracted out some shared examples in order to test both of our
druuid generating methods (`.gen` and `.min_for_time`)